### PR TITLE
Switched paleo.climatemirror.org to France and success tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
                                     |
                                     <span class="tag tag-primary">FTP</span>
                                     |
-                                    <span class="tag tag-warning">US</span>
+                                    <span class="tag tag-success">France</span>
                                     |
                                     Nick Santos
                                 </h6>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
                                     |
                                     <span class="tag tag-primary">FTP</span>
                                     |
-                                    <span class="tag tag-success">France</span>
+                                    <span class="tag tag-success">Non-US</span>
                                     |
                                     Nick Santos
                                 </h6>


### PR DESCRIPTION
Maybe should just be "Non-US" as I saw above